### PR TITLE
Optional per-game configuration files.

### DIFF
--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -1003,6 +1003,10 @@ function next_core() { # next_core (core)
 	if [ -z "${rompath}" ]; then
 		core_error "${nextcore}" "${rompath}"
 	else
+		if [ -f "${rompath}.sam" ]; then
+			source "${rompath}.sam"
+		fi
+		
 		declare -g romloadfails=0
 		load_core "${nextcore}" "${rompath}" "${romname%.*}" "${countdown}"
 	fi


### PR DESCRIPTION
I would like to be able to specify some behavior on a per game basis. An ideal implementation would handle the following use cases:

- Specify a unique attract mode time value.
- Ability to script a single button press after some amount of time. This would be useful for some GBA games that have `Health and Safety` warning screens so that they can be skipped automatically. 
- A general configuration option to filter out games without per-game configuration files.
- Some kind of probability control.

This MR implements a basic version of this. It uses a complimentary `$(romname).sam` file next to game rom to specify custom properties. Currently only handles overriding the countdown value per game.

A couple of examples:

```bash
# Legend of Zelda - A Link to the Past (USA).sfc.sam
counter=172

#  This config file for Link to the Past plays the whole opening one time through,
#  with some extra time at the end to show the logo again.
#  If the next game has no configuration file, it will use the default time in the `MiSTer_SAM.ini` 

```

```bash
# Rhythm Tengoku (JAPAN).gba.sam
counter=90
simulate_a_press=3 

# This mock-up config file for Rhythm Tengoku simulates an `A` button to bypass 
# "Health and Safety" screen after 3 seconds...
```

This is mostly a proof of concept. There might be a better way to load the configuration files that are more user friendly, but I wanted to share this idea. Let me know what you think...

Thanks!