### PR TITLE
Prevent customized MRA list from being overwritten if it exists

### DIFF
--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -1075,6 +1075,11 @@ function build_mralist() {
 		echo " The path ${arcadepath} contains no MRA files!"
 		loop_core
 	fi
+
+	# Check if the MRA list already exists - if so, leave it alone
+	if [ -f ${mralist} ]; then
+		return
+	fi
 	
 	# This prints the list of MRA files in a path,
 	# Cuts the string to just the file name,


### PR DESCRIPTION
If you have a customized MRA list, it gets clobbered each time MiSTer_SAM_on.sh runs, deleting any changes you previously made.