### PR TITLE
Console whitelists and configurable MiSTer_SAM repository

### DIFF
--- a/MiSTer_SAM.ini
+++ b/MiSTer_SAM.ini
@@ -29,13 +29,24 @@ usezip="Yes"
 # Disable bootroms directory so your default games don't boot during Attract Mode cycles 
 disablebootrom="Yes"
 
+# Custom List of Console ROM Files
+# You can specify a list of console games you would like to display
+# by creating the files below; missing files are ignored.
+# Each file should have one game per line and use Unix-style line endings.
+gbawhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_gba.txt"
+genesiswhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_genesis.txt"
+megacdwhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_megacd.txt"
+neogeowhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_neogeo.txt"
+neswhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_nes.txt"
+sneswhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_snes.txt"
+tgfx16whitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_tgfx16.txt"
+tgfx16cdwhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_tgfx16cd.txt"
 
 # ======== ARCADE OPTIONS ========
 # Custom List of Arcade MRA Files
 # You can specify a list of Arcade Games you would like to display
 # Or exclude Games instead in the next setting
 #mralist="/media/fat/Scripts/MiSTer_SAM_mras.txt"
-
 
 #======== EXCLUDE LISTS ========
 # One game per line
@@ -134,6 +145,10 @@ ttydevice="/dev/ttyUSB0"
 #samquiet="No"
 #samdebug="Yes"
 #samtrace="Yes"
+
+# GitHub repository to download updates from
+# Change this to use your own fork
+#repository_url="https://github.com/mrchrisster/MiSTer_SAM"
 
 # GitHub branch to download updates from
 # Valid choices are: "main" or "test"

--- a/MiSTer_SAM.ini
+++ b/MiSTer_SAM.ini
@@ -29,10 +29,11 @@ usezip="Yes"
 # Disable bootroms directory so your default games don't boot during Attract Mode cycles 
 disablebootrom="Yes"
 
-# Custom List of Console ROM Files
+# ======== CONSOLE WHITELISTS ========
 # You can specify a list of console games you would like to display
-# by creating the files below; missing files are ignored.
+# by creating the files below; missing or empty files are ignored.
 # Each file should have one game per line and use Unix-style line endings.
+# Game names are not case-sensitive.
 gbawhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_gba.txt"
 genesiswhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_genesis.txt"
 megacdwhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_megacd.txt"

--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -958,7 +958,7 @@ function next_core() { # next_core (core)
 		local romwhitelisttest=( -true )
 	fi
 
-	local folderexcludetest=( -type d '(' -iname *BIOS* ${fldrex} ')' -prune -false -o )
+	local folderexcludetest=( -type d '(' -iname *BIOS* -o -iname ' !MBC' ${fldrex} ')' -prune -false -o )
 	local romtest=( -iname "*.${CORE_EXT[${nextcore,,}]}" "${romwhitelisttest[@]}" )
 	if [ "${CORE_ZIPPED[${nextcore,,}],,}" == "yes" ] && [ "${usezip,,}" == "yes" ]; then
 		if [ "${samquiet,,}" == "no" ]; then echo " Ignoring zip files."; fi

--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -943,10 +943,23 @@ function next_core() { # next_core (core)
 		return
 	fi
 
+	declare -n whitelist="${nextcore,,}whitelist"
+	# Use the whitelist
+	if [ -s "${whitelist}" ]; then
+		local zipwhitelisttest=( -exec bash -c 'unzip -Z1 "{}" | grep -Fiqxf '"${whitelist}" ';' )
+		local zipwhitelistfilter=( grep -Fixf "${whitelist}" )
+		local romwhitelisttest=( -exec bash -c 'rom=$(basename "{}"); grep -Fqx "${rom}" '"${whitelist}" ';' )
+	else
+	# No whitelist present
+		local zipwhitelisttest=( -exec bash -c 'unzip -Z1 "{}" | grep -Eiqx '".*\\.${CORE_EXT[${nextcore,,}]}" ';' )
+		local zipwhitelistfilter=( grep -Eix ".*\\.${CORE_EXT[${nextcore,,}]}" )
+		local romwhitelisttest=( -true )
+	fi
+
 	# Core doesn't use zips - get on with it
 	if [ "${CORE_ZIPPED[${nextcore,,}],,}" == "no" ]; then
 		if [ "${samquiet,,}" == "no" ]; then echo " ${nextcore,,} does not use ZIPs."; fi
-		rompath="$(find ${CORE_PATH[${nextcore,,}]} -type d \( -iname *BIOS* ${fldrex} \) -prune -false -o -type f -iname "*.${CORE_EXT[${nextcore,,}]}" | shuf --head-count=1 --random-source=/dev/urandom)"
+		rompath="$(find ${CORE_PATH[${nextcore,,}]} -type d \( -iname *BIOS* ${fldrex} \) -prune -false -o -type f -iname "*.${CORE_EXT[${nextcore,,}]}" "${romwhitelisttest[@]}" -print | shuf --head-count=1 --random-source=/dev/urandom)"
 		romname=$(basename "${rompath}")
 	
 	# We might be using ZIPs
@@ -962,9 +975,11 @@ function next_core() { # next_core (core)
 			if [ "${samquiet,,}" == "no" ]; then echo " Both ROMs and ZIPs found!"; fi
 
 			# We found at least one large ZIP file - use it
-			if [ $(find ${CORE_PATH[${nextcore,,}]} -maxdepth 1 -xdev -type f -size +500M \( -iname "*.zip" \) -print | wc -l) -gt 0 ]; then
+			if [ $(find ${CORE_PATH[${nextcore,,}]} -maxdepth 1 -xdev -type f -size +500M \( -iname "*.zip" \) "${zipwhitelisttest[@]}" -print | wc -l) -gt 0 ]; then
 				if [ "${samquiet,,}" == "no" ]; then echo " Using 500MB+ ZIP(s)."; fi
-				romname=$("${mrsampath}/partun" "$(find ${CORE_PATH[${nextcore,,}]} -xdev -maxdepth 1 -size +500M -type f -iname "*.zip" | shuf --head-count=1 --random-source=/dev/urandom)" -i -r -f ${CORE_EXT[${nextcore,,}]} --rename /tmp/Extracted.${CORE_EXT[${nextcore,,}]})
+				zipname=$(find ${CORE_PATH[${nextcore,,}]} -xdev -maxdepth 1 -size +500M -type f -iname "*.zip" "${zipwhitelisttest[@]}" -print | shuf --head-count=1 --random-source=/dev/urandom)
+				zippedrom=$(unzip -Z1 "${zipname}" | "${zipwhitelistfilter[@]}" | shuf --head-count=1 --random-source=/dev/urandom)
+				romname=$("${mrsampath}/partun" "${zipname}" -i -f "${zippedrom}" --rename /tmp/Extracted.${CORE_EXT[${nextcore,,}]})
 				# Partun returns the actual rom name to us so we need a special case here
 				romname=$(basename "${romname}")
 				rompath="/tmp/Extracted.${CORE_EXT[${nextcore,,}]}"
@@ -972,7 +987,9 @@ function next_core() { # next_core (core)
 			# We see more zip files than ROMs - individually zipped roms?
 			elif [ ${zipcount} -gt ${romcount} ]; then
 				if [ "${samquiet,,}" == "no" ]; then echo " Fewer ROMs - using ZIPs."; fi
-				romname=$("${mrsampath}/partun" "$(find ${CORE_PATH[${nextcore,,}]} -maxdepth 1 -type f -iname "*.zip" | shuf --head-count=1 --random-source=/dev/urandom)" -i -r -f ${CORE_EXT[${nextcore,,}]} --rename /tmp/Extracted.${CORE_EXT[${nextcore,,}]})
+				zipname=$(find ${CORE_PATH[${nextcore,,}]} -maxdepth 1 -type f -iname "*.zip" "${zipwhitelisttest[@]}" -print | shuf --head-count=1 --random-source=/dev/urandom)
+				zippedrom=$(unzip -Z1 "${zipname}" | "${zipwhitelistfilter[@]}" | shuf --head-count=1 --random-source=/dev/urandom)
+				romname=$("${mrsampath}/partun" "${zipname}" -i -f "${zippedrom}" --rename /tmp/Extracted.${CORE_EXT[${nextcore,,}]})
 				# Partun returns the actual rom name to us so we need a special case here
 				romname=$(basename "${romname}")
 				rompath="/tmp/Extracted.${CORE_EXT[${nextcore,,}]}"
@@ -980,34 +997,24 @@ function next_core() { # next_core (core)
 			# I guess we use the ROMs!
 			else
 				if [ "${samquiet,,}" == "no" ]; then echo " Using ROMs."; fi
-				rompath="$(find ${CORE_PATH[${nextcore,,}]} -type d \( -iname *BIOS* ${fldrex} \) -prune -false -o -iname "*.${CORE_EXT[${nextcore,,}]}" | shuf --head-count=1 --random-source=/dev/urandom)"
+				rompath=$(find ${CORE_PATH[${nextcore,,}]} -type d \( -iname *BIOS* ${fldrex} \) -prune -false -o -iname "*.${CORE_EXT[${nextcore,,}]}" "${romwhitelisttest[@]}" -print | shuf --head-count=1 --random-source=/dev/urandom)
 				romname=$(basename "${rompath}")
 			fi
 
 		# Found no ZIPs or we're ignoring them
-		elif [ -z "$(find ${CORE_PATH[${nextcore,,}]} -maxdepth 1 -type f \( -iname "*.zip" \))" ] || [ "${usezip,,}" == "no" ]; then
-			rompath="$(find ${CORE_PATH[${nextcore,,}]} -type d \( -iname *BIOS* ${fldrex} \) -prune -false -o -iname "*.${CORE_EXT[${nextcore,,}]}" | shuf --head-count=1 --random-source=/dev/urandom)"
+		elif [ ${zipcount} -eq 0 ] || [ "${usezip,,}" == "no" ]; then
+			rompath=$(find ${CORE_PATH[${nextcore,,}]} -type d \( -iname *BIOS* ${fldrex} \) -prune -false -o -iname "*.${CORE_EXT[${nextcore,,}]}" "${romwhitelisttest[@]}" -print | shuf --head-count=1 --random-source=/dev/urandom)
 			romname=$(basename "${rompath}")
 
 		# Use the ZIP Luke!
 		else
-			romname=$("${mrsampath}/partun" "$(find ${CORE_PATH[${nextcore,,}]} -maxdepth 1 -type f -iname "*.zip" | shuf --head-count=1 --random-source=/dev/urandom)" -i -r -f ${CORE_EXT[${nextcore,,}]} --rename /tmp/Extracted.${CORE_EXT[${nextcore,,}]})
+			zipname=$(find ${CORE_PATH[${nextcore,,}]} -maxdepth 1 -type f -iname "*.zip" "${zipwhitelisttest[@]}" -print | shuf --head-count=1 --random-source=/dev/urandom)
+			zippedrom=$(unzip -Z1 "${zipname}" | "${zipwhitelistfilter[@]}" | shuf --head-count=1 --random-source=/dev/urandom)
+			romname=$("${mrsampath}/partun" "${zipname}" -i -f "${zippedrom}" --rename /tmp/Extracted.${CORE_EXT[${nextcore,,}]})
 			# Partun returns the actual rom name to us so we need a special case here
 			romname=$(basename "${romname}")
 			rompath="/tmp/Extracted.${CORE_EXT[${nextcore,,}]}"
 		fi
-	fi
-
-	# If there is a whitelist check it
-	declare -n whitelist="${nextcore,,}list"
-	# Possible exit statuses:
-	# 0: found
-	# 1: not found
-	# 2: error (e.g. file not found)
-	if [ $(grep -Fqsx "${romname}" "${whitelist}"; echo "$?") -eq 1 ]; then
-		echo " ${romname} is not in ${whitelist} - SKIPPED"
-		next_core
-		return
 	fi
 
 	# If there is an exclude list check it

--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -22,7 +22,7 @@
 # Additional development by: Mellified
 #
 # Thanks for the contributions and support:
-# pocomane, kaloun34, redsteakraw, RetroDriven, woelper, LamerDeluxe
+# pocomane, kaloun34, redsteakraw, RetroDriven, woelper, LamerDeluxe, InquisitiveCoder
 
 
 #!/bin/bash
@@ -54,6 +54,7 @@ disablebootrom="Yes"
 listenmouse="Yes"
 listenkeyboard="Yes"
 listenjoy="Yes"
+repository_url="https://github.com/mrchrisster/MiSTer_SAM"
 branch="main"
 mbcurl="blob/master/mbc_v06"
 
@@ -71,6 +72,16 @@ nespath="/media/fat/games/NES"
 snespath="/media/fat/games/SNES"
 tgfx16path="/media/fat/games/TGFX16"
 tgfx16cdpath="/media/fat/games/TGFX16-CD"
+
+# ======== CONSOLE WHITELISTS ========
+gbawhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_gba.txt"
+genesiswhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_genesis.txt"
+megacdwhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_megacd.txt"
+neogeowhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_neogeo.txt"
+neswhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_nes.txt"
+sneswhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_snes.txt"
+tgfx16whitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_tgfx16.txt"
+tgfx16cdwhitelist="/media/fat/Scripts/MiSTer_SAM_whitelist_tgfx16cd.txt"
 
 #======== EXCLUDE LISTS ========
 arcadeexclude="First Bad Game.mra
@@ -718,9 +729,8 @@ function get_samstuff() { #get_samstuff file (path)
 		filepath="${mrsampath}"
 	fi
 
-	REPOSITORY_URL="https://github.com/mrchrisster/MiSTer_SAM"
-		echo -n " Downloading from ${REPOSITORY_URL}/blob/${branch}/${1} to ${filepath}/..."
-	curl_download "/tmp/${1##*/}" "${REPOSITORY_URL}/blob/${branch}/${1}?raw=true"
+	echo -n " Downloading from ${repository_url}/blob/${branch}/${1} to ${filepath}/..."
+	curl_download "/tmp/${1##*/}" "${repository_url}/blob/${branch}/${1}?raw=true"
 
 	if [ ! "${filepath}" == "/tmp" ]; then
 		mv --force "/tmp/${1##*/}" "${filepath}/${1##*/}"
@@ -988,6 +998,18 @@ function next_core() { # next_core (core)
 		fi
 	fi
 
+	# If there is a whitelist check it
+	declare -n whitelist="${nextcore,,}list"
+	# Possible exit statuses:
+	# 0: found
+	# 1: not found
+	# 2: error (e.g. file not found)
+	if [ $(grep -Fqsx "${romname}" "${whitelist}"; echo "$?") -eq 1 ]; then
+		echo " ${romname} is not in ${whitelist} - SKIPPED"
+		next_core
+		return
+	fi
+
 	# If there is an exclude list check it
 	declare -n excludelist="${nextcore,,}exclude"
 	if [ ${#excludelist[@]} -gt 0 ]; then
@@ -1148,6 +1170,7 @@ if [ "${samtrace,,}" == "yes" ]; then
 	echo ""
 	#======== LOCAL VARIABLES ========
 	echo " commandline: ${@}"
+	echo " repository_url: ${repository_url}"
 	echo " branch: ${branch}"
 	echo " mbcurl: ${mbcurl}"
 	echo ""
@@ -1169,7 +1192,16 @@ if [ "${samtrace,,}" == "yes" ]; then
 	echo " snespath: ${snespath}"
 	echo " tgfx16path: ${tgfx16path}"
 	echo " tgfx16cdpath: ${tgfx16cdpath}"
-  echo ""
+	echo ""
+	echo " gbalist: ${gbalist}"
+	echo " genesislist: ${genesislist}"
+	echo " megacdlist: ${megacdlist}"
+	echo " neogeolist: ${neogeolist}"
+	echo " neslist: ${neslist}"
+	echo " sneslist: ${sneslist}"
+	echo " tgfx16list: ${tgfx16list}"
+	echo " tgfx16cdlist: ${tgfx16cdlist}"
+	echo ""
 	echo " arcadeexclude: ${arcadeexclude[@]}"
 	echo " gbaexclude: ${gbaexclude[@]}"
 	echo " genesisexclude: ${genesisexclude[@]}"


### PR DESCRIPTION
This patch addresses issue #90 by introducing optional whitelist files for each console core. If the file exists and is not empty, only games from the list will be used.

The change is accomplished by adding tests to `find` such that ROM files that are not in the whitelist, and zip files that don't contain at least one ROM in the whitelist, are excluded from `find`'s output. The whitelist is also used when selecting which random ROM to extract from the zip file.

A simpler approach would've been to check the whitelist right before the exclude list, but during testing I found this would result in a large number of skips and calls to `next_core` if the whitelist is small relative to the number of ROMs. Filtering the files during the `find` command ensures the script doesn't waste time selecting the wrong ROMs.

The exclusion list is still checked last, so if a file is mistakenly listed in both the whitelist and exclude list, the exclude list takes priority.

I also made a minor change to make the SAM repository configurable, since I wanted the script to use my fork of the code during testing.

**EDIT**: I found the old code hard to manage and test so I took the liberty of unifying the zip and non-zip logic. Rather than choosing from one of many code paths based on heuristics (i.e. number of zip files, number of ROM files, size of the zips), the new code considers both ROMs *and* zips in one call to `find`. This allows all of the scenarios the old code was trying to manage (one big zip, one ROM per zip, unzipped ROMs) to be handled uniformly.

I recognize this last change isn't strictly backwards compatible, so if you'd prefer I roll it back, let me know.