### PR TITLE
Fix cleanup code for inotifywait.

### DIFF
--- a/.MiSTer_SAM/MiSTer_SAM_MCP
+++ b/.MiSTer_SAM/MiSTer_SAM_MCP
@@ -77,7 +77,7 @@ killall -q -9 MiSTer_SAM_joy.py
 killall -q -9 MiSTer_SAM_mouse.sh
 killall -q -9 MiSTer_SAM_keyboard.sh
 killall -q -9 xxd
-kill -9 $(ps | grep "inotifywait" | grep "SAM_Joy_Change" | cut --fields=2 --only-delimited --delimiter=' ')
+kill -9 $(ps -o pid,args | grep "inotifywait" | grep "SAM_Joy_Change" | { read -r PID COMMAND; echo $PID; })
 echo " Done!"
 
 # Convert seconds to minutes

--- a/.MiSTer_SAM/MiSTer_SAM_init
+++ b/.MiSTer_SAM/MiSTer_SAM_init
@@ -81,7 +81,7 @@ killall -q -9 MiSTer_SAM_joy.py
 killall -q -9 MiSTer_SAM_mouse.sh
 killall -q -9 MiSTer_SAM_keyboard.sh
 killall -q -9 xxd
-kill -9 $(ps aux | grep "inotifywait" | grep "SAM_Joy_Change" | cut --fields=2 --only-delimited --delimiter=' ')
+kill -9 $(ps -o pid,args | grep "inotifywait" | grep "SAM_Joy_Change" | { read -r PID COMMAND; echo $PID; })
 echo " Done!"
 
 


### PR DESCRIPTION
The code responsible for finding the PID of inotifywait isn't working. My guess is MiSTer changed its `ps` implementation at some point and the current version of `ps` has a different output format from when this code was written. The current `ps` version tries to align its output using multiple spaces, which makes `cut` impractical.

The new code specifies the output columns for `ps` and uses `read`'s built-in word splitting to parse the PID. Hopefully this'll be more resilient to formatting changes.