### PR TITLE
TTY2OLED screen saver is now disabled when TTY2OLED is initialized.

### DIFF
--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -721,6 +721,7 @@ function tty_init() { # tty_init
 		#echo " Stopping tty2oled daemon..."
 		#/etc/init.d/S60tty2oled stop
 		#echo " Done!"
+		echo "CMDSAVER,0,0,0" > "${ttydevice}" # Disable screen saver
 		
 		echo "CMDCLS" > "${ttydevice}"
 		waitforttyack


### PR DESCRIPTION
Disable the TTY2OLED screen saver while SAM is active, so it doesn't start while SAM is showing game information.