### PR TITLE
tty2oled Support Updates

### DIFF
--- a/MiSTer_SAM.ini
+++ b/MiSTer_SAM.ini
@@ -107,10 +107,10 @@ psxpath="/media/fat/games/PSX"
 # ======== TTY2OLED =======
 # Options for https://github.com/venice1200/MiSTer_tty2oled
 # usetty="Yes" shows the text name of the game being played - NOT the standard core name graphic
+# All needed values are read from the tty2oled INI files
 ttyenable="No"
-ttydevice="/dev/ttyUSB0"
-ttypicture="/media/fat/tty2oled/pics"          
-ttypicture_pri="/media/fat/tty2oled/pics_pri"   
+ttysystemini="/media/fat/tty2oled/tty2oled-system.ini"
+ttyuserini="/media/fat/tty2oled/tty2oled-user.ini"
 
 
 # Use the ZIP files in your game directories. It's best to leave it untouched.

--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -536,6 +536,7 @@ function parse_cmd() {
 					break
 					;;
 				stop) # Stop SAM immediately
+					tty_exit
 					there_can_be_only_one
 					echo " Thanks for playing!"
 			 
@@ -892,11 +893,26 @@ function tty_senddata() {
   fi													# End if Picture check
 }
 
+function tty_exit() { # tty_exit
+	if [ "${ttyenable,,}" == "yes" ]; then
+		# Starting tty2oled daemon
+		echo " Starting tty2oled daemon..."
+		/media/fat/tty2oled/S60tty2oled start
+		echo " Done!"
+		sleep 2
+	fi
+}
+
 function tty_init() { # tty_init
 	# tty2oled initialization
 	if [ "${ttyenable,,}" == "yes" ]; then
 
-		echo " Init tty2oled... "
+		echo " Init tty2oled, loading variables... "
+		source ${ttysystemini}
+		source ${ttyuserini}
+		ttydevice=${TTYDEV}
+		ttypicture=${picturefolder}
+		ttypicture_pri=${picturefolder_pri}
 		
 		# Clear Serial input buffer first
 		echo " Clear tty2oled Serial Input Buffer "
@@ -946,6 +962,7 @@ function tty_init() { # tty_init
 		sleep 0.2
 		echo "CMDTXT,3,15,0,147,61, Mode!" > "${ttydevice}"
 		tty_waitforack
+		sleep 3
 	fi
 }
 
@@ -1269,7 +1286,7 @@ function load_core() { # load_core core /path/to/rom name_of_rom (countdown)
 	echo -e "\e[1m${3}\e[0m"
 	echo "$(date +%H:%M:%S) - ${1} - ${3}" >> /tmp/SAM_Games.log
 	echo "${3} (${1})" > /tmp/SAM_Game.txt
-	tty_update "${CORE_PRETTY[${1,,}]}" "${3}" "${1}"&
+	tty_update "${CORE_PRETTY[${1,,}]}" "${3}" "${CORE_LAUNCH[${1,,}]}" &
 	
 
 
@@ -1372,7 +1389,7 @@ function load_core_arcade() {
 	echo -e "\e[1m${mraname}\e[0m"
 	echo "$(date +%H:%M:%S) - Arcade - ${mraname}" >> /tmp/SAM_Games.log
 	echo "${mraname} (${nextcore})" > /tmp/SAM_Game.txt
-	tty_update "${CORE_PRETTY[${nextcore,,}]}" "${mraname}" "${nextcore}"
+	tty_update "${CORE_PRETTY[${nextcore,,}]}" "${mraname}" "${CORE_LAUNCH[${nextcore},,}]}"
 
 	if [ "${1}" == "countdown" ]; then
 		for i in {5..1}; do


### PR DESCRIPTION
Moin,
the SAM INI contains only tty2oled yes/no and the paths to the tty2oled ini files which will be sourced at tty_init.
Means you get tty device and picture paths from the tty2oled configuration.

New ist tty_exit which starts the tty2oled daemon if tty2oled was set to yes.

I use now "${CORE_LAUNCH[${1,,}]}" and "${CORE_LAUNCH[${nextcore},,}]}" (for Arcade) to identify the corename 
which is needed to find the core picture. 
This should be the right one now as a fds game is now loding the nes picture.

Cheers