### PR TITLE
Allow Use Default Rom Paths

### DIFF
--- a/MiSTer_SAM.ini
+++ b/MiSTer_SAM.ini
@@ -108,6 +108,10 @@ listenjoy="Yes"
 
 # ======== GAME PATHS ========
 # Game path customization. Useful if you only want to show certain games in your collection or use alternative media storage like `/media/usb0`
+# Uses the default rom locations that MiSTer and all cores use by default
+# This allows you to have your roms in /media/usb0/games, for example, without needing to edit the paths, below.
+usedefaultpaths="Yes"
+
 # Default - all arcade games
 # Uncomment below to use only rotated games
 # arcadepath="/media/fat/_Arcade/_Organized/_4 Video & Inputs/_2 Rotation/_Horizontal"


### PR DESCRIPTION
This will allow SAM to automatically find the Rom paths, even if some are on /media/fat/games/ and others are on /media/usb(0-5)/games/ as well as a few other paths searched by MiSTer and the cores.