### PR TITLE
Some quick error fixes

### DIFF
--- a/MiSTer_SAM.ini
+++ b/MiSTer_SAM.ini
@@ -113,8 +113,6 @@ listenjoy="Yes"
 usedefaultpaths="No"
 
 # Default - all arcade games
-# Uncomment below to use only rotated games
-# arcadepath="/media/fat/_Arcade/_Organized/_4 Video & Inputs/_2 Rotation/_Horizontal"
 arcadepath="/media/fat/_Arcade"
 fdspath="/media/fat/games/NES"
 gbpath="/media/fat/Games/Gameboy"
@@ -125,7 +123,7 @@ ggpath="/media/fat/games/SMS"
 megacdpath="/media/fat/games/MegaCD"
 neogeopath="/media/fat/games/NeoGeo"
 nespath="/media/fat/games/NES"
-s32xpath="/media/fat/Games/Genesis"
+s32xpath="/media/fat/Games/S32X"
 smspath="/media/fat/Games/SMS"
 snespath="/media/fat/games/SNES"
 tgfx16path="/media/fat/games/TGFX16"
@@ -134,6 +132,8 @@ psxpath="/media/fat/games/PSX"
 
 #-------- CORE PATHS EXTRA --------
 
+# Uncomment below to use only rotated games
+# arcadepathextra="_Organized/_4 Video & Inputs/_2 Rotation/_Horizontal"
 arcadepathextra=""
 fdspathextra=""
 gbpathextra=""

--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -807,7 +807,7 @@ function parse_cmd() {
 					tty_exit
 					if [ "${mute,,}" == "yes" ]; then echo -e "\0000\c" > /media/fat/config/Volume.dat; fi
 					echo " Thanks for playing!"
-					if [ "${mute,,}" == "yes" ]; then "load_core /media/fat/menu.rbf" > /dev/MiSTer_cmd; fi
+					if [ "${mute,,}" == "yes" ]; then echo "load_core /media/fat/menu.rbf" > /dev/MiSTer_cmd; fi
 					exit
 					break
 					;;


### PR DESCRIPTION
If the user wants to only use roms in a subfolder of the main rom directory, it must be added in the pathextra fields

Somehow the genesis/s32x mix up got missed in the ini file, in a previous commit

echo left out of the stop commandline option