### PR TITLE
Fix romlist creation to use all roms and zips

### DIFF
--- a/MiSTer_SAM.ini
+++ b/MiSTer_SAM.ini
@@ -93,7 +93,7 @@ Third Bad Game.chd"
 # Folders and files you would like to exlude, like NSF (Audio files for NES) for example. You don't need to include the full path or file name.
 # Partial names with case insensitive spelling will suffice.
 
-exclude=( vgm nsf nes2pce spc unsupported )
+exclude=( vgm nsf nes2pce spc unsupported sounds )
 
 # -------- ADVANCED (HANDLE WITH CARE) --------
 # When you push a button or move the mouse, interrupt SAM

--- a/MiSTer_SAM.ini
+++ b/MiSTer_SAM.ini
@@ -131,9 +131,9 @@ tgfx16cdpath="/media/fat/games/TGFX16-CD"
 psxpath="/media/fat/games/PSX"
 
 #-------- CORE PATHS EXTRA --------
-
+# Path must begin with /
 # Uncomment below to use only rotated games
-# arcadepathextra="_Organized/_4 Video & Inputs/_2 Rotation/_Horizontal"
+# arcadepathextra="/_Organized/_4 Video & Inputs/_2 Rotation/_Horizontal"
 arcadepathextra=""
 fdspathextra=""
 gbpathextra=""

--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -1577,6 +1577,8 @@ function next_core() { # next_core (core)
 	fi
 
 
+	DIR=$(echo $(realpath -s --canonicalize-missing "${CORE_PATH[${nextcore,,}]}${CORE_PATH_EXTRA[${nextcore,,}]}"))
+
 	### Declare functions first
 
 
@@ -1590,7 +1592,7 @@ function next_core() { # next_core (core)
 	
 	function stat_compare() {
 	
-		DIR_TO_CHECK="${CORE_PATH[${nextcore,,}]}/${CORE_PATH_EXTRA[${nextcore,,}]}"
+		DIR_TO_CHECK="${DIR}"
 		OLD_STAT_FILE="${countpath}/${nextcore,,}_stat"
 		if [ -e "$OLD_STAT_FILE" ]; then
 				OLD_STAT=$(cat "$OLD_STAT_FILE")
@@ -1601,7 +1603,7 @@ function next_core() { # next_core (core)
 		NEW_STAT=$(stat -t "${DIR_TO_CHECK}")
 		
 		if [ “"${OLD_STAT}"” != “"${NEW_STAT}"” ]; then
-				if [ "${samquiet,,}" == "no" ]; then echo " Directory ${CORE_PATH[${nextcore,,}]}/${CORE_PATH_EXTRA[${nextcore,,}]} was modified or this is the first core launch. Regenerating game lists..."; fi
+				if [ "${samquiet,,}" == "no" ]; then echo " Directory ${DIR} was modified or this is the first core launch. Regenerating game lists..."; fi
 				reset_core_gl
 				echo "$NEW_STAT" > "$OLD_STAT_FILE"
 		fi
@@ -1609,12 +1611,12 @@ function next_core() { # next_core (core)
 	
 	
 	function create_romlist() {
-		echo " Looking for games in ${CORE_PATH[${nextcore,,}]}/${CORE_PATH_EXTRA[${nextcore,,}]} ..."
-		find -L "${CORE_PATH[${nextcore,,}]}${CORE_PATH_EXTRA[${nextcore,,}]}" \( -type l -o -type d \) \( -iname *BIOS* ${findex} \) -prune -false -o -not -path '*/.*' -type f \( -iname "*.${CORE_EXT[${nextcore,,}]}" ! -iname *BIOS* ${findex} \) -fprint "${tmpfile}"
+		echo " Looking for games in  ${DIR}..."
+		find -L "${DIR}" \( -type l -o -type d \) \( -iname *BIOS* ${findex} \) -prune -false -o -not -path '*/.*' -type f \( -iname "*.${CORE_EXT[${nextcore,,}]}" ! -iname *BIOS* ${findex} \) -fprint "${tmpfile}"
 
 		#Find all zips and process
 		if [ "${CORE_ZIPPED[${nextcore,,}],,}" == "yes" ]; then
-			find -L "${CORE_PATH[${nextcore,,}]}${CORE_PATH_EXTRA[${nextcore,,}]}" \( -type l -o -type d \) \( -iname *BIOS* ${findex} \) -prune -false -o -not -path '*/.*' -type f \( -iname "*.zip" ! -iname *BIOS* ${findex} \) -fprint "${tmpfile2}"
+			find -L "${DIR}" \( -type l -o -type d \) \( -iname *BIOS* ${findex} \) -prune -false -o -not -path '*/.*' -type f \( -iname "*.zip" ! -iname *BIOS* ${findex} \) -fprint "${tmpfile2}"
 			shopt -s nullglob
 			if [ -s "${tmpfile2}" ]; then
 				local IFS=$'\n'
@@ -1643,8 +1645,8 @@ function next_core() { # next_core (core)
 		fi
 
 		#If folder changed, make new list
-		if [[ ! "$(cat ${gamelistpath}/${nextcore,,}_gamelist.txt | grep "${CORE_PATH[${nextcore,,}]}/${CORE_PATH_EXTRA[${nextcore,,}]}" | head -1)" ]]; then
-			if [ "${samquiet,,}" == "no" ]; then echo " Creating new game list because folder "${CORE_PATH[${nextcore,,}]}/${CORE_PATH_EXTRA[${nextcore,,}]}" changed in ini."; fi
+		if [[ ! "$(cat ${gamelistpath}/${nextcore,,}_gamelist.txt | grep "${DIR}" | head -1)" ]]; then
+			if [ "${samquiet,,}" == "no" ]; then echo " Creating new game list because folder "${DIR}" changed in ini."; fi
 			create_romlist
 		fi
 
@@ -1840,10 +1842,12 @@ function unmute() {
 
 # ======== ARCADE MODE ========
 function build_mralist() {
+	DIR=$(echo $(realpath -s --canonicalize-missing "${CORE_PATH[${nextcore,,}]}${CORE_PATH_EXTRA[${nextcore,,}]}"))
+
 	# If no MRAs found - suicide!
-	find "${arcadepath}" -type f \( -iname "*.mra" \) &>/dev/null
+	find "${DIR}" -type f \( -iname "*.mra" \) &>/dev/null
 	if [ ! ${?} == 0 ]; then
-		echo " The path ${arcadepath} contains no MRA files!"
+		echo " The path ${DIR} contains no MRA files!"
 		loop_core
 	fi
 
@@ -1854,13 +1858,15 @@ function build_mralist() {
 	# If there is an empty exclude list ignore it
 	# Otherwise use it to filter the list
 	if [ ${#arcadeexclude[@]} -eq 0 ]; then
-		find "${arcadepath}" -not -path '*/.*' -type f \( -iname "*.mra" \)  | cut -c $(( $(echo ${#arcadepath}) + 2 ))- >"${mralist}"
+		find "${DIR}" -not -path '*/.*' -type f \( -iname "*.mra" \)  | cut -c $(( $(echo ${#DIR}) + 2 ))- >"${mralist}"
 	else
-		find "${arcadepath}" -not -path '*/.*' -type f \( -iname "*.mra" \)  | cut -c $(( $(echo ${#arcadepath}) + 2 ))- | grep -vFf <(printf '%s\n' ${arcadeexclude[@]})>"${mralist}"
+		find "${DIR}" -not -path '*/.*' -type f \( -iname "*.mra" \)  | cut -c $(( $(echo ${#DIR}) + 2 ))- | grep -vFf <(printf '%s\n' ${arcadeexclude[@]})>"${mralist}"
 	fi
 }
 
 function load_core_arcade() {
+
+	DIR=$(echo $(realpath -s --canonicalize-missing "${CORE_PATH[${nextcore,,}]}${CORE_PATH_EXTRA[${nextcore,,}]}"))
 
 	# Check if the MRA list is empty or doesn't exist - if so, make a new list
 
@@ -1870,18 +1876,20 @@ function load_core_arcade() {
 
 	# Get a random game from the list
 	mra="$(shuf --head-count=1 ${mralist})"
+	MRAPATH=$(echo $(realpath -s --canonicalize-missing "${DIR}/${mra}"))
 
 	# If the mra variable is valid this is skipped, but if not we try 10 times
 	# Partially protects against typos from manual editing and strange character parsing problems
 	for i in {1..10}; do
-		if [ ! -f "${arcadepath}/${mra}" ]; then
+		if [ ! -f "${MRAPATH}" ]; then
 			mra=$(shuf --head-count=1 ${mralist})
+			MRAPATH=$(echo $(realpath -s --canonicalize-missing "${DIR}/${mra}"))
 		fi
 	done
 
 	# If the MRA is still not valid something is wrong - suicide
-	if [ ! -f "${arcadepath}/${mra}" ]; then
-		echo " There is no valid file at ${arcadepath}/${mra}!"
+	if [ ! -f "${MRAPATH}" ]; then
+		echo " There is no valid file at ${MRAPATH}!"
 		return
 	fi
 
@@ -1899,7 +1907,7 @@ function load_core_arcade() {
 	echo "${mraname} (${nextcore,,})" > /tmp/SAM_Game.txt
 
 	# Get Setname from MRA needed for tty2oled, thx to RealLarry
-	mrasetname=$(grep "<setname>" "${arcadepath}/${mra}" | sed -e 's/<setname>//' -e 's/<\/setname>//' | tr -cd '[:alnum:]')
+	mrasetname=$(grep "<setname>" "${MRAPATH}" | sed -e 's/<setname>//' -e 's/<\/setname>//' | tr -cd '[:alnum:]')
 	tty_update "${CORE_PRETTY[${nextcore,,}]}" "${mraname}" "${mrasetname}" &  # Non-Blocking
 	#tty_update "${CORE_PRETTY[${nextcore,,}]}" "${mraname}" "${mrasetname}"    # Blocking
 
@@ -1911,7 +1919,7 @@ function load_core_arcade() {
 	fi
 
   # Tell MiSTer to load the next MRA
-  echo "load_core ${arcadepath}/${mra}" > /dev/MiSTer_cmd
+  echo "load_core ${MRAPATH}" > /dev/MiSTer_cmd
  	sleep 1
 	echo "" |>/tmp/.SAM_Joy_Activity
 	echo "" |>/tmp/.SAM_Mouse_Activity

--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -1893,6 +1893,8 @@ function load_core_arcade() {
 		return
 	fi
 
+	if [ "${samquiet,,}" == "no" ]; then echo " Selected file: ${MRAPATH}"; fi
+
 	#Delete mra from list so it doesn't repeat
 	if [ "${norepeat,,}" == "yes" ]; then
 		awk -vLine="$mra" '!index($0,Line)' "${mralist}"  > ${tmpfile} && mv ${tmpfile} "${mralist}"


### PR DESCRIPTION
I found a few use cases that didn't work with the previous setup, including extensions that were uppercase, in zips and, it also wasn't searching subdirectories for zip files and would choke on zips with spaces in their names

Added sounds to filenames to ignore (I have some .pce files that just play sounds from games, no visuals...)

I also added a line that backs up the previous mgl file before creating the new one, for debugging purposes.

One benefit of this is you don't need to keep roms for systems in completely separate directories, such as GB and GBC the script will only select the proper roms for each system, from all the zips it finds.

I also added code to prevent it searching for zips for systems that don't use zips, for some reason with PSX, it would think some chds were zips, and fail to create a psx romlist.