### PR TITLE
More 8266 stabilty

### DIFF
--- a/.MiSTer_SAM/MiSTer_SAM_tty2oled
+++ b/.MiSTer_SAM/MiSTer_SAM_tty2oled
@@ -84,15 +84,18 @@ function tty_init() { # tty_init
 	# Stopping ScreenSaver
 	samquiet "-n" " Stopping tty2oled ScreenSaver..."
 	echo "CMDSAVER,0,0,0" >${ttydevice}
-	sleep 2
+	tty_waitfor
+	#sleep 2
 	samquiet " Done!"
 	
 	#Show Splash
 	echo "CMDAPD,SAM_splash" >${ttydevice}
 	tail -n +4 "/media/fat/tty2oled/pics/GSC/SAM_splash.gsc" | xxd -r -p >${ttydevice}
+	tty_waitfor
 	echo "CMDSPIC,-1" >${ttydevice}
-	sleep 5
-	
+	tty_waitfor
+	sleep 4
+	#sleep 5
 }
 
 


### PR DESCRIPTION
Moin/Hi,
as I wrote in one of my last mails I added a few more **tty_waitfor** in the tty part of SAM.
This will give more stabilty for 8266 usage.

I run a test with a 8266 with the serial chip CH340G, the same ESP as Antonio sells.
With the little delay in MiSTer_SAM_on.sh I get everything running and I get the MENU Logo each time back to the display with both ESPs.

```
function tty_exit() {
	if [ "${ttyenable}" == "yes" ]; then
		echo -n " Stopping tty2oled... "
		tmux kill-session -t OLED &>/dev/null
		sleep 1 #TEST 
		rm "${tty_sleepfile}" &>/dev/null
		echo "Done."
	fi
```

As a note, I never recommend 8266.
Antonio or one of his corporate never asked which device they should take.