### PR TITLE
echo current game to /tmp/ACTIVEGAME

### DIFF
--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -2769,6 +2769,7 @@ function load_core() { # load_core core [/path/to/rom] [name_of_rom]
 
     echo "$(date +%H:%M:%S) - ${core} - ${rompath:-$gamename}" >>/tmp/SAM_Games.log
     echo "${gamename} (${core})" >/tmp/SAM_Game.txt
+    echo "${gamename}" >/tmp/ACTIVEGAME
 
     if [ "${ttyenable}" == "yes" ]; then
         local tty_gamename="${gamename}"


### PR DESCRIPTION
Along with SAM I also use MiSTer Remote on my MiSTer. When games are playing with SAM currently the active game is echo'ed to `/tmp/SAM_Game.txt`, but MiSTer Remote reads `/tmp/ACTIVEGAME` for the currently running game, so in it shows the current game as `None`. I've added that here so I can see from MiSTer Remote which game SAM is currently running.