### PR TITLE
echo gamename to /tmp/ACTIVENAME

### DIFF
--- a/MiSTer_SAM_on.sh
+++ b/MiSTer_SAM_on.sh
@@ -2976,6 +2976,7 @@ function load_core() { # load_core core [/path/to/rom] [name_of_rom]
 
     echo "$(date +%H:%M:%S) - ${core} - ${rompath:-$gamename}" >>/tmp/SAM_Games.log
     echo "${gamename} (${core})" >/tmp/SAM_Game.txt
+    echo "${gamename}" >/tmp/ACTIVEGAME
 
     if [ "${ttyenable}" == "yes" ]; then
         local tty_gamename="${gamename}"


### PR DESCRIPTION
This pull request introduces a small change to the `load_core` function in `MiSTer_SAM_on.sh`. The change adds a line to write the current game's name to the `/tmp/ACTIVEGAME` file, likely for easier tracking or integration with other scripts. 

* The current game's name is now written to `/tmp/ACTIVEGAME` when a core is loaded.